### PR TITLE
Move the orphaned ephemerons GC colour check inside the barrier.

### DIFF
--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -2094,6 +2094,8 @@ void caml_domain_terminate(bool last)
 
     caml_finish_marking();
 
+    /* Orphaning does not happen in [Phase_sweep_main]. */
+    CAMLassert (caml_gc_phase != Phase_sweep_main);
     caml_orphan_ephemerons(domain_state);
     caml_orphan_finalisers(domain_state);
 


### PR DESCRIPTION
This PR fixes the multicoretests failures observed in https://github.com/ocaml/ocaml/pull/13580#issuecomment-3085691431.

On trunk, the check (call it, "C")

```
  /* Ephemerons */
#ifdef DEBUG
  orph_ephe_list_verify_status (caml_global_heap_state.UNMARKED);
#endif
```

https://github.com/ocaml/ocaml/blob/5e89966f8fee3e4d4829e29d0abe1ac02c757aad/runtime/major_gc.c#L1668-L1671

appears in `stw_cycle_all_domains`. Importantly, the correctness of this check C depends on the global barrier that follows later in the same function: 
https://github.com/ocaml/ocaml/blob/5e89966f8fee3e4d4829e29d0abe1ac02c757aad/runtime/major_gc.c#L1689-L1692. This barrier prevents other domains from proceeding out of the function before every domain has had a chance to do that check C. 

In the `mark-delay` code, the check C appears, but the barrier is removed, as we only need to wait for the global roots to be marked. This allows a domain D to mark the global roots and then continue to potentially run the mutator (and other runtime functions) before another domain has had a chance to run the check C. In particular, this domain D may go ahead and orphan ephemerons (and mark them while doing so). Afterwards, one of the other domains may run the check C and observe it with an incorrect status.

The fix is to move this check C into the body of the `Caml_global_barrier_if_final`. In fact, running this check after adopting orphaned work, as in the code prior to this PR, would never find ephemerons from the previous cycle, which is what it was intended to check the status of. 
